### PR TITLE
Updated Cloudstack Portforward Classname

### DIFF
--- a/libcloud_rest/api/entries.py
+++ b/libcloud_rest/api/entries.py
@@ -460,7 +460,7 @@ class CloudStackAddressEntry(LibcloudObjectEntry):
 
 
 class CloudStackForwardingRuleEntry(LibcloudObjectEntry):
-    object_class = compute_cloudstack.CloudStackForwardingRule
+    object_class = compute_cloudstack.CloudStackPortForwardingRule
     render_attrs = ('node', 'id', 'address', 'protocol',
                     'start_port', 'end_port')
 
@@ -469,7 +469,7 @@ class CloudStackForwardingRuleEntry(LibcloudObjectEntry):
 
     def _get_object(self, json_data, driver=None):
         rule_id = json_data['cloudstack_forwarding_rule_id']
-        return compute_cloudstack.CloudStackForwardingRule(
+        return compute_cloudstack.CloudStackPortForwardingRule(
             None, rule_id, None, None, None)
 
 


### PR DESCRIPTION
Looks like the classname got updated:

https://github.com/apache/libcloud/blob/trunk/libcloud/compute/drivers/cloudstack.py#L372

Requesting a merge.
